### PR TITLE
cleaning out LiveStore duplicate code

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // This is manually built for now
 
-import { Fetcher, NamedNode, Store, UpdateManager } from 'rdflib'
-import {SolidLogic} from 'solid-logic';
+import { NamedNode } from 'rdflib'
+import { SolidLogic, LiveStore } from 'solid-logic';
 
 declare const list: Array<PaneDefinition>
 declare const paneForIcon: { [key: string]: PaneDefinition }
@@ -18,14 +18,6 @@ declare function register (
 ): void
 
 declare function byName (name: string): PaneDefinition | null
-
-export class ConnectedStore extends Store {
-  public fetcher: Fetcher
-}
-
-export class LiveStore extends ConnectedStore {
-  public updater: UpdateManager
-}
 
 /**
  * All of the knowledge that a user accumulates throughout the current session

--- a/paneRegistry.js
+++ b/paneRegistry.js
@@ -55,18 +55,4 @@ paneRegistry.byName = function (name) {
   return null
 }
 
-paneRegistry.ConnectedStore = class ConnectedStore extends $rdf.Store {
-  constructor (features) {
-    super(features)
-    this.fetcher = $rdf.fetcher(this, {})
-  }
-}
-
-paneRegistry.LiveStore = class LiveStore extends $rdf.Store {
-  constructor (features) {
-    super(features)
-    this.updater = new $rdf.UpdateManager(this)
-  }
-}
-
 // ENDS


### PR DESCRIPTION
This is a code refactoring spanning over more modules. Before this PR is merged one needs to merge the following PR (order is NOT important since they depend only on pane-registry and not on changes made to each other):

- [x]  https://github.com/solid/activitystreams-pane/pull/7
- [x] https://github.com/solid/solid-panes/pull/327
- [x] https://github.com/solid/solid-ui/pull/462
- [x] https://github.com/solid/profile-pane/pull/26

In this refactoring, I checked all panes for potential existing dependency on pane-registry LiveStore and cleaned them all which were mentioned in: https://github.com/solid/profile-pane/pull/26
